### PR TITLE
Making homebrew and zerobrew blazingly fast.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,12 +149,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -386,6 +408,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,11 +470,13 @@ dependencies = [
 
 [[package]]
 name = "fex"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "crossterm 0.28.1",
  "ratatui",
+ "reqwest",
+ "serde",
 ]
 
 [[package]]
@@ -454,6 +489,12 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "finl_unicode"
@@ -486,6 +527,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,14 +596,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -553,6 +667,187 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +858,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -596,6 +912,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -686,6 +1018,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +1052,12 @@ checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac_address"
@@ -867,6 +1211,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pest"
 version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,7 +1286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -962,16 +1312,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -990,6 +1370,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1013,7 +1448,27 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1021,6 +1476,15 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "ratatui"
@@ -1146,6 +1610,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1702,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1248,6 +1807,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1828,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -1296,10 +1873,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1335,6 +1934,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1959,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1481,6 +2106,125 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,6 +2272,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +2326,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1595,6 +2372,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1661,6 +2452,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1762,6 +2582,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1931,6 +2760,115 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fex"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "A universal interactive package search TUI"
 license = "MIT"
@@ -13,3 +13,5 @@ categories = ["command-line-utilities"]
 clap = { version = "4.5.60", features = ["derive"] }
 ratatui = "0.30.0"
 crossterm = "0.28"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,12 +1,13 @@
+use std::io::Stdout;
 use std::sync::{Arc, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
-use std::io::Stdout;
 
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use ratatui::{Terminal, backend::CrosstermBackend};
 
 use crate::provider::{BoxedProvider, Package, SearchResult};
+use crate::providers::homebrew_index;
 use crate::ui;
 
 pub enum SearchState {
@@ -187,15 +188,13 @@ impl App {
                 self.selected = 0;
                 self.scroll_offset = 0;
                 if let Some(err) = result.error {
-                    self.status_message = format!("Error: {err}");
+                    self.status_message = err;
                 } else if self.packages.is_empty() {
                     self.status_message = "No results found.".to_string();
                 } else {
                     let n = self.packages.len();
-                    self.status_message = format!(
-                        "Found {n} result{}.",
-                        if n == 1 { "" } else { "s" }
-                    );
+                    self.status_message =
+                        format!("Found {n} result{}.", if n == 1 { "" } else { "s" });
                 }
                 self.search_state = SearchState::Done;
             }
@@ -214,7 +213,11 @@ impl App {
             } else {
                 self.generation += 1;
                 self.search_state = SearchState::Searching;
-                self.status_message = "Searching...".to_string();
+                self.status_message = if self.is_loading_homebrew_index() {
+                    "Loading Homebrew index...".to_string()
+                } else {
+                    "Searching...".to_string()
+                };
                 self.spawn_search(query);
             }
             self.query_changed = false;
@@ -229,5 +232,9 @@ impl App {
             let result = provider.search(&query);
             tx.send((search_gen, result)).ok();
         });
+    }
+
+    fn is_loading_homebrew_index(&self) -> bool {
+        matches!(self.provider.name(), "brew" | "zerobrew") && !homebrew_index::is_initialized()
     }
 }

--- a/src/providers/apk.rs
+++ b/src/providers/apk.rs
@@ -9,7 +9,11 @@ pub struct ApkProvider;
 
 fn get_installed() -> HashSet<String> {
     let output = exec_command("apk info 2>/dev/null");
-    output.lines().filter(|l| !l.is_empty()).map(|l| l.to_string()).collect()
+    output
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
 }
 
 /// Split "name-version" by the last hyphen followed by a digit.
@@ -36,13 +40,19 @@ impl Provider for ApkProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
         let output = exec_command(&format!("apk search -v '{escaped}' 2>/dev/null"));
         if output.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let installed = get_installed();
@@ -53,7 +63,9 @@ impl Provider for ApkProvider {
                 continue;
             }
             // Format: package-name-version - description
-            let Some(sep) = line.find(" - ") else { continue };
+            let Some(sep) = line.find(" - ") else {
+                continue;
+            };
             let name_version = &line[..sep];
             let description = line[sep + 3..].to_string();
 
@@ -69,7 +81,10 @@ impl Provider for ApkProvider {
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/apt.rs
+++ b/src/providers/apt.rs
@@ -9,7 +9,11 @@ pub struct AptProvider;
 
 fn get_installed() -> HashSet<String> {
     let output = exec_command("dpkg-query -W -f='${Package}\\n' 2>/dev/null");
-    output.lines().filter(|l| !l.is_empty()).map(|l| l.to_string()).collect()
+    output
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
 }
 
 impl Provider for AptProvider {
@@ -23,13 +27,19 @@ impl Provider for AptProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
         let output = exec_command(&format!("apt-cache search '{escaped}' 2>/dev/null"));
         if output.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let installed = get_installed();
@@ -40,7 +50,9 @@ impl Provider for AptProvider {
                 continue;
             }
             // Format: package-name - description
-            let Some(sep) = line.find(" - ") else { continue };
+            let Some(sep) = line.find(" - ") else {
+                continue;
+            };
             let name = line[..sep].to_string();
             let description = line[sep + 3..].to_string();
             let is_installed = installed.contains(&name);
@@ -54,7 +66,10 @@ impl Provider for AptProvider {
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/brew.rs
+++ b/src/providers/brew.rs
@@ -1,26 +1,10 @@
-use std::collections::HashSet;
-
 use ratatui::style::Color;
 
 use crate::provider::{Package, Provider, SearchResult};
-use crate::util::{command_exists, escape_query, exec_command, sort_by_relevance};
+use crate::providers::homebrew_index;
+use crate::util::command_exists;
 
 pub struct BrewProvider;
-
-fn get_installed() -> HashSet<String> {
-    let mut installed = HashSet::new();
-    for output in [
-        exec_command("brew list --formula 2>/dev/null"),
-        exec_command("brew list --cask 2>/dev/null"),
-    ] {
-        for line in output.lines() {
-            if !line.is_empty() {
-                installed.insert(line.to_string());
-            }
-        }
-    }
-    installed
-}
 
 impl Provider for BrewProvider {
     fn name(&self) -> &str {
@@ -32,96 +16,7 @@ impl Provider for BrewProvider {
     }
 
     fn search(&self, query: &str) -> SearchResult {
-        if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
-        }
-
-        let escaped = escape_query(query);
-        let installed = get_installed();
-
-        // Try exact match via brew info
-        let mut exact_match: Option<Package> = None;
-        let info_output = exec_command(&format!("brew info '{escaped}' 2>/dev/null"));
-        if !info_output.is_empty() && !info_output.contains("Error:") {
-            let mut lines = info_output.lines();
-            if let Some(first_line) = lines.next() {
-                let first_line = first_line.strip_prefix("==> ").unwrap_or(first_line);
-                if let Some(colon) = first_line.find(": ") {
-                    let name = first_line[..colon].to_string();
-                    // Find description (skip empty, =, http, Installed, From:, License:)
-                    let description = lines
-                        .find(|l| {
-                            !l.is_empty()
-                                && !l.starts_with('=')
-                                && !l.starts_with("http")
-                                && !l.starts_with("Installed")
-                                && !l.starts_with("From:")
-                                && !l.starts_with("License:")
-                        })
-                        .unwrap_or("")
-                        .to_string();
-                    let is_installed = installed.contains(&name);
-                    exact_match = Some(Package {
-                        name,
-                        version: String::new(),
-                        description,
-                        source: "formula".to_string(),
-                        installed: is_installed,
-                    });
-                }
-            }
-        }
-
-        let output = exec_command(&format!("brew search --desc '{escaped}' 2>/dev/null"));
-
-        let mut packages = Vec::new();
-
-        // Add exact match first
-        let exact_name = exact_match.as_ref().map(|p| p.name.clone()).unwrap_or_default();
-        if let Some(em) = exact_match {
-            packages.push(em);
-        }
-
-        let mut current_source = "formula";
-        for line in output.lines() {
-            if line.is_empty() {
-                continue;
-            }
-            if line.contains("==> Formulae") {
-                current_source = "formula";
-                continue;
-            }
-            if line.contains("==> Casks") {
-                current_source = "cask";
-                continue;
-            }
-            // Skip other headers
-            if line.starts_with('=') || line.starts_with("No ") {
-                continue;
-            }
-
-            let (name, description) = if let Some(colon) = line.find(": ") {
-                (line[..colon].to_string(), line[colon + 2..].to_string())
-            } else {
-                (line.trim().to_string(), String::new())
-            };
-
-            if name.is_empty() || name == exact_name {
-                continue;
-            }
-
-            let is_installed = installed.contains(&name);
-            packages.push(Package {
-                name,
-                version: String::new(),
-                description,
-                source: current_source.to_string(),
-                installed: is_installed,
-            });
-        }
-
-        sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        homebrew_index::search(query)
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/dnf.rs
+++ b/src/providers/dnf.rs
@@ -9,7 +9,11 @@ pub struct DnfProvider;
 
 fn get_installed() -> HashSet<String> {
     let output = exec_command("rpm -qa --qf '%{NAME}\\n' 2>/dev/null");
-    output.lines().filter(|l| !l.is_empty()).map(|l| l.to_string()).collect()
+    output
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
 }
 
 impl Provider for DnfProvider {
@@ -23,13 +27,19 @@ impl Provider for DnfProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
         let output = exec_command(&format!("dnf search '{escaped}' 2>/dev/null"));
         if output.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let installed = get_installed();
@@ -54,7 +64,9 @@ impl Provider for DnfProvider {
 
             // Format: "name.arch   description"
             let Some(dot) = line.find('.') else { continue };
-            let Some(arch_end) = line.find(' ') else { continue };
+            let Some(arch_end) = line.find(' ') else {
+                continue;
+            };
             if arch_end <= dot {
                 continue;
             }
@@ -78,7 +90,10 @@ impl Provider for DnfProvider {
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/flatpak.rs
+++ b/src/providers/flatpak.rs
@@ -9,7 +9,11 @@ pub struct FlatpakProvider;
 
 fn get_installed() -> HashSet<String> {
     let output = exec_command("flatpak list --columns=application 2>/dev/null");
-    output.lines().filter(|l| !l.is_empty()).map(|l| l.to_string()).collect()
+    output
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
 }
 
 impl Provider for FlatpakProvider {
@@ -23,13 +27,19 @@ impl Provider for FlatpakProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
         let output = exec_command(&format!("flatpak search '{escaped}' 2>/dev/null"));
         if output.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let installed = get_installed();
@@ -51,9 +61,17 @@ impl Provider for FlatpakProvider {
             }
             let description = cols[1].trim().to_string();
             let app_id = cols[2].trim().to_string();
-            let version = if cols.len() > 3 { cols[3].trim().to_string() } else { String::new() };
+            let version = if cols.len() > 3 {
+                cols[3].trim().to_string()
+            } else {
+                String::new()
+            };
             let remote = if cols.len() > 5 {
-                cols[5].split_whitespace().next().unwrap_or("flathub").to_string()
+                cols[5]
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("flathub")
+                    .to_string()
             } else {
                 "flathub".to_string()
             };
@@ -73,7 +91,10 @@ impl Provider for FlatpakProvider {
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/homebrew_index.rs
+++ b/src/providers/homebrew_index.rs
@@ -1,0 +1,327 @@
+use std::cmp::Ordering;
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+use crate::provider::{Package, SearchResult};
+use crate::util::{escape_query, exec_command};
+
+const FORMULA_API_URL: &str = "https://formulae.brew.sh/api/formula.json";
+const CASK_API_URL: &str = "https://formulae.brew.sh/api/cask.json";
+
+static HOMEBREW_INDEX: OnceLock<Result<Vec<HomebrewEntry>, String>> = OnceLock::new();
+
+#[derive(Clone)]
+struct HomebrewEntry {
+    name: String,
+    description: String,
+    source: String,
+    search_terms: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct FormulaApiEntry {
+    name: String,
+    #[serde(default)]
+    desc: Option<String>,
+    #[serde(default)]
+    aliases: Vec<String>,
+    #[serde(default)]
+    oldnames: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct CaskApiEntry {
+    token: String,
+    #[serde(default)]
+    desc: Option<String>,
+    #[serde(default)]
+    old_tokens: Vec<String>,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum MatchKind {
+    Exact,
+    StartsWith,
+    Contains,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+struct MatchRank {
+    kind: MatchKind,
+    term_len: usize,
+    name_len: usize,
+}
+
+impl Ord for MatchRank {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.kind
+            .cmp(&other.kind)
+            .then_with(|| other.term_len.cmp(&self.term_len))
+            .then_with(|| other.name_len.cmp(&self.name_len))
+    }
+}
+
+impl PartialOrd for MatchRank {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for MatchKind {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.priority().cmp(&other.priority())
+    }
+}
+
+impl PartialOrd for MatchKind {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl MatchKind {
+    fn priority(self) -> u8 {
+        match self {
+            MatchKind::Contains => 0,
+            MatchKind::StartsWith => 1,
+            MatchKind::Exact => 2,
+        }
+    }
+}
+
+pub fn is_initialized() -> bool {
+    HOMEBREW_INDEX.get().is_some()
+}
+
+pub fn search(query: &str) -> SearchResult {
+    if query.is_empty() {
+        return SearchResult {
+            packages: vec![],
+            error: None,
+        };
+    }
+
+    let installed = get_installed();
+
+    match load_index() {
+        Ok(index) => SearchResult {
+            packages: search_index(index, query, &installed),
+            error: None,
+        },
+        Err(_) => {
+            let mut result = cli_search(query, &installed);
+            let count = result.packages.len();
+            result.error = Some(if count == 0 {
+                "Homebrew index unavailable, using slower CLI search.".to_string()
+            } else {
+                format!(
+                    "Homebrew index unavailable, using slower CLI search ({count} result{}).",
+                    if count == 1 { "" } else { "s" }
+                )
+            });
+            result
+        }
+    }
+}
+
+fn get_installed() -> HashSet<String> {
+    let mut installed = HashSet::new();
+    for output in [
+        exec_command("brew list --formula 2>/dev/null"),
+        exec_command("brew list --cask 2>/dev/null"),
+    ] {
+        for line in output.lines() {
+            if !line.is_empty() {
+                installed.insert(line.to_string());
+            }
+        }
+    }
+    installed
+}
+
+fn load_index() -> Result<&'static Vec<HomebrewEntry>, String> {
+    HOMEBREW_INDEX
+        .get_or_init(fetch_index)
+        .as_ref()
+        .map_err(|err| err.clone())
+}
+
+fn fetch_index() -> Result<Vec<HomebrewEntry>, String> {
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(concat!("fex/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|err| format!("failed to create HTTP client: {err}"))?;
+
+    let formulae: Vec<FormulaApiEntry> = client
+        .get(FORMULA_API_URL)
+        .send()
+        .and_then(|response| response.error_for_status())
+        .map_err(|err| format!("failed to fetch formula index: {err}"))?
+        .json()
+        .map_err(|err| format!("failed to parse formula index: {err}"))?;
+
+    let casks: Vec<CaskApiEntry> = client
+        .get(CASK_API_URL)
+        .send()
+        .and_then(|response| response.error_for_status())
+        .map_err(|err| format!("failed to fetch cask index: {err}"))?
+        .json()
+        .map_err(|err| format!("failed to parse cask index: {err}"))?;
+
+    let mut entries = Vec::with_capacity(formulae.len() + casks.len());
+    entries.extend(formulae.into_iter().map(|item| {
+        let FormulaApiEntry {
+            name,
+            desc,
+            aliases,
+            oldnames,
+        } = item;
+
+        let search_terms = normalize_terms(
+            std::iter::once(&name)
+                .chain(aliases.iter())
+                .chain(oldnames.iter()),
+        );
+
+        HomebrewEntry {
+            name,
+            description: desc.unwrap_or_default(),
+            source: "formula".to_string(),
+            search_terms,
+        }
+    }));
+    entries.extend(casks.into_iter().map(|item| {
+        let CaskApiEntry {
+            token,
+            desc,
+            old_tokens,
+        } = item;
+
+        let search_terms = normalize_terms(std::iter::once(&token).chain(old_tokens.iter()));
+
+        HomebrewEntry {
+            name: token,
+            description: desc.unwrap_or_default(),
+            source: "cask".to_string(),
+            search_terms,
+        }
+    }));
+
+    Ok(entries)
+}
+
+fn normalize_terms<'a>(terms: impl IntoIterator<Item = &'a String>) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for term in terms {
+        let term = term.to_lowercase();
+        if !normalized.contains(&term) {
+            normalized.push(term);
+        }
+    }
+    normalized
+}
+
+fn search_index(index: &[HomebrewEntry], query: &str, installed: &HashSet<String>) -> Vec<Package> {
+    let query_lower = query.to_lowercase();
+    let mut matches: Vec<(MatchRank, &HomebrewEntry)> = index
+        .iter()
+        .filter_map(|entry| best_match(entry, &query_lower).map(|rank| (rank, entry)))
+        .collect();
+
+    matches.sort_by(|(a_rank, a_entry), (b_rank, b_entry)| {
+        b_rank
+            .cmp(a_rank)
+            .then_with(|| a_entry.name.cmp(&b_entry.name))
+    });
+
+    matches
+        .into_iter()
+        .map(|(_, entry)| Package {
+            name: entry.name.clone(),
+            version: String::new(),
+            description: entry.description.clone(),
+            source: entry.source.clone(),
+            installed: installed.contains(&entry.name),
+        })
+        .collect()
+}
+
+fn best_match(entry: &HomebrewEntry, query: &str) -> Option<MatchRank> {
+    entry
+        .search_terms
+        .iter()
+        .filter_map(|term| {
+            if term == query {
+                Some(MatchRank {
+                    kind: MatchKind::Exact,
+                    term_len: term.len(),
+                    name_len: entry.name.len(),
+                })
+            } else if term.starts_with(query) {
+                Some(MatchRank {
+                    kind: MatchKind::StartsWith,
+                    term_len: term.len(),
+                    name_len: entry.name.len(),
+                })
+            } else if term.contains(query) {
+                Some(MatchRank {
+                    kind: MatchKind::Contains,
+                    term_len: term.len(),
+                    name_len: entry.name.len(),
+                })
+            } else {
+                None
+            }
+        })
+        .max()
+}
+
+fn cli_search(query: &str, installed: &HashSet<String>) -> SearchResult {
+    let escaped = escape_query(query);
+    let output = exec_command(&format!("brew search --desc '{escaped}' 2>/dev/null"));
+
+    let mut packages = Vec::new();
+    let mut current_source = "formula";
+
+    for line in output.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        if line.contains("==> Formulae") {
+            current_source = "formula";
+            continue;
+        }
+        if line.contains("==> Casks") {
+            current_source = "cask";
+            continue;
+        }
+        if line.starts_with('=') || line.starts_with("No ") {
+            continue;
+        }
+
+        let (name, description) = if let Some(colon) = line.find(": ") {
+            (line[..colon].to_string(), line[colon + 2..].to_string())
+        } else {
+            (line.trim().to_string(), String::new())
+        };
+
+        if name.is_empty() {
+            continue;
+        }
+
+        packages.push(Package {
+            installed: installed.contains(&name),
+            name,
+            version: String::new(),
+            description,
+            source: current_source.to_string(),
+        });
+    }
+
+    SearchResult {
+        packages,
+        error: None,
+    }
+}

--- a/src/providers/homebrew_index.rs
+++ b/src/providers/homebrew_index.rs
@@ -17,7 +17,8 @@ struct HomebrewEntry {
     name: String,
     description: String,
     source: String,
-    search_terms: Vec<String>,
+    primary_terms: Vec<String>,
+    secondary_terms: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -35,9 +36,17 @@ struct FormulaApiEntry {
 struct CaskApiEntry {
     token: String,
     #[serde(default)]
+    name: Vec<String>,
+    #[serde(default)]
     desc: Option<String>,
     #[serde(default)]
     old_tokens: Vec<String>,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum MatchTier {
+    Secondary,
+    Primary,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -49,6 +58,7 @@ enum MatchKind {
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 struct MatchRank {
+    tier: MatchTier,
     kind: MatchKind,
     term_len: usize,
     name_len: usize,
@@ -56,8 +66,9 @@ struct MatchRank {
 
 impl Ord for MatchRank {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.kind
-            .cmp(&other.kind)
+        self.tier
+            .cmp(&other.tier)
+            .then_with(|| self.kind.cmp(&other.kind))
             .then_with(|| other.term_len.cmp(&self.term_len))
             .then_with(|| other.name_len.cmp(&self.name_len))
     }
@@ -66,6 +77,27 @@ impl Ord for MatchRank {
 impl PartialOrd for MatchRank {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl Ord for MatchTier {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.priority().cmp(&other.priority())
+    }
+}
+
+impl PartialOrd for MatchTier {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl MatchTier {
+    fn priority(self) -> u8 {
+        match self {
+            MatchTier::Secondary => 0,
+            MatchTier::Primary => 1,
+        }
     }
 }
 
@@ -87,6 +119,26 @@ impl MatchKind {
             MatchKind::Contains => 0,
             MatchKind::StartsWith => 1,
             MatchKind::Exact => 2,
+        }
+    }
+}
+
+impl MatchRank {
+    fn primary(kind: MatchKind, term_len: usize, name_len: usize) -> Self {
+        Self {
+            tier: MatchTier::Primary,
+            kind,
+            term_len,
+            name_len,
+        }
+    }
+
+    fn secondary(kind: MatchKind, term_len: usize, name_len: usize) -> Self {
+        Self {
+            tier: MatchTier::Secondary,
+            kind,
+            term_len,
+            name_len,
         }
     }
 }
@@ -179,33 +231,43 @@ fn fetch_index() -> Result<Vec<HomebrewEntry>, String> {
             oldnames,
         } = item;
 
-        let search_terms = normalize_terms(
+        let primary_terms = normalize_terms(
             std::iter::once(&name)
                 .chain(aliases.iter())
                 .chain(oldnames.iter()),
         );
+        let secondary_terms = tokenize_text(desc.as_deref().unwrap_or(""));
 
         HomebrewEntry {
             name,
             description: desc.unwrap_or_default(),
             source: "formula".to_string(),
-            search_terms,
+            primary_terms,
+            secondary_terms,
         }
     }));
     entries.extend(casks.into_iter().map(|item| {
         let CaskApiEntry {
             token,
+            name,
             desc,
             old_tokens,
         } = item;
 
-        let search_terms = normalize_terms(std::iter::once(&token).chain(old_tokens.iter()));
+        let primary_terms = normalize_terms(std::iter::once(&token).chain(old_tokens.iter()));
+        let mut secondary_terms = tokenize_texts(name.iter());
+        for term in tokenize_text(desc.as_deref().unwrap_or("")) {
+            if !secondary_terms.contains(&term) {
+                secondary_terms.push(term);
+            }
+        }
 
         HomebrewEntry {
             name: token,
             description: desc.unwrap_or_default(),
             source: "cask".to_string(),
-            search_terms,
+            primary_terms,
+            secondary_terms,
         }
     }));
 
@@ -215,7 +277,7 @@ fn fetch_index() -> Result<Vec<HomebrewEntry>, String> {
 fn normalize_terms<'a>(terms: impl IntoIterator<Item = &'a String>) -> Vec<String> {
     let mut normalized = Vec::new();
     for term in terms {
-        let term = term.to_lowercase();
+        let term = normalize_term(term);
         if !normalized.contains(&term) {
             normalized.push(term);
         }
@@ -223,8 +285,57 @@ fn normalize_terms<'a>(terms: impl IntoIterator<Item = &'a String>) -> Vec<Strin
     normalized
 }
 
+fn tokenize_texts<'a>(texts: impl IntoIterator<Item = &'a String>) -> Vec<String> {
+    let mut terms = Vec::new();
+    for text in texts {
+        for term in tokenize_text(text) {
+            if !terms.contains(&term) {
+                terms.push(term);
+            }
+        }
+    }
+    terms
+}
+
+fn tokenize_text(text: &str) -> Vec<String> {
+    let mut terms = Vec::new();
+    let normalized = normalize_term(text);
+    if normalized.is_empty() {
+        return terms;
+    }
+
+    terms.push(normalized.clone());
+
+    for term in normalized.split_whitespace() {
+        if term.len() < 3 {
+            continue;
+        }
+        let term = term.to_string();
+        if !terms.contains(&term) {
+            terms.push(term);
+        }
+    }
+
+    terms
+}
+
+fn normalize_term(term: &str) -> String {
+    term.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn search_index(index: &[HomebrewEntry], query: &str, installed: &HashSet<String>) -> Vec<Package> {
-    let query_lower = query.to_lowercase();
+    let query_lower = normalize_term(query);
     let mut matches: Vec<(MatchRank, &HomebrewEntry)> = index
         .iter()
         .filter_map(|entry| best_match(entry, &query_lower).map(|rank| (rank, entry)))
@@ -250,31 +361,54 @@ fn search_index(index: &[HomebrewEntry], query: &str, installed: &HashSet<String
 
 fn best_match(entry: &HomebrewEntry, query: &str) -> Option<MatchRank> {
     entry
-        .search_terms
+        .primary_terms
         .iter()
         .filter_map(|term| {
             if term == query {
-                Some(MatchRank {
-                    kind: MatchKind::Exact,
-                    term_len: term.len(),
-                    name_len: entry.name.len(),
-                })
+                Some(MatchRank::primary(
+                    MatchKind::Exact,
+                    term.len(),
+                    entry.name.len(),
+                ))
             } else if term.starts_with(query) {
-                Some(MatchRank {
-                    kind: MatchKind::StartsWith,
-                    term_len: term.len(),
-                    name_len: entry.name.len(),
-                })
+                Some(MatchRank::primary(
+                    MatchKind::StartsWith,
+                    term.len(),
+                    entry.name.len(),
+                ))
             } else if term.contains(query) {
-                Some(MatchRank {
-                    kind: MatchKind::Contains,
-                    term_len: term.len(),
-                    name_len: entry.name.len(),
-                })
+                Some(MatchRank::primary(
+                    MatchKind::Contains,
+                    term.len(),
+                    entry.name.len(),
+                ))
             } else {
                 None
             }
         })
+        .chain(entry.secondary_terms.iter().filter_map(|term| {
+            if term == query {
+                Some(MatchRank::secondary(
+                    MatchKind::Exact,
+                    term.len(),
+                    entry.name.len(),
+                ))
+            } else if term.starts_with(query) {
+                Some(MatchRank::secondary(
+                    MatchKind::StartsWith,
+                    term.len(),
+                    entry.name.len(),
+                ))
+            } else if term.contains(query) {
+                Some(MatchRank::secondary(
+                    MatchKind::Contains,
+                    term.len(),
+                    entry.name.len(),
+                ))
+            } else {
+                None
+            }
+        }))
         .max()
 }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -3,6 +3,7 @@ pub mod apt;
 pub mod brew;
 pub mod dnf;
 pub mod flatpak;
+pub mod homebrew_index;
 pub mod nix;
 pub mod pacman;
 pub mod paru;
@@ -72,5 +73,8 @@ pub fn get_available_providers() -> Vec<(&'static str, BoxedProvider)> {
         ("snap", Box::new(snap::SnapProvider)),
         ("flatpak", Box::new(flatpak::FlatpakProvider)),
     ];
-    candidates.into_iter().filter(|(_, p)| p.is_available()).collect()
+    candidates
+        .into_iter()
+        .filter(|(_, p)| p.is_available())
+        .collect()
 }

--- a/src/providers/nix.rs
+++ b/src/providers/nix.rs
@@ -34,7 +34,10 @@ impl Provider for NixProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
@@ -53,12 +56,18 @@ impl Provider for NixProvider {
             // Format: "nixpkgs.name    name-version    Description"
             // Columns are space-padded (no tabs), so we can't use splitn on whitespace chars.
             // Instead, find the boundary of each field manually.
-            let Some(ws1) = line.find(|c: char| c.is_ascii_whitespace()) else { continue };
+            let Some(ws1) = line.find(|c: char| c.is_ascii_whitespace()) else {
+                continue;
+            };
             let attr = &line[..ws1];
-            if attr.is_empty() { continue; }
+            if attr.is_empty() {
+                continue;
+            }
 
             let rest = line[ws1..].trim_start();
-            if rest.is_empty() { continue; }
+            if rest.is_empty() {
+                continue;
+            }
 
             let (name_version, description) = match rest.find(|c: char| c.is_ascii_whitespace()) {
                 Some(ws2) => (&rest[..ws2], rest[ws2..].trim_start()),
@@ -81,7 +90,10 @@ impl Provider for NixProvider {
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/pacman.rs
+++ b/src/providers/pacman.rs
@@ -47,10 +47,14 @@ fn parse_ss_output(output: &str) -> Vec<Package> {
                 packages.push(pkg);
             }
             // Parse: repo/name version [installed]
-            let Some(slash) = line.find('/') else { continue };
+            let Some(slash) = line.find('/') else {
+                continue;
+            };
             let source = line[..slash].to_string();
             let rest = &line[slash + 1..];
-            let Some(space) = rest.find(' ') else { continue };
+            let Some(space) = rest.find(' ') else {
+                continue;
+            };
             let name = rest[..space].to_string();
             let after_name = &rest[space + 1..];
             let version = after_name
@@ -59,7 +63,13 @@ fn parse_ss_output(output: &str) -> Vec<Package> {
                 .unwrap_or("")
                 .to_string();
             let installed = line.contains("[installed]") || line.contains("[Installed]");
-            current = Some(Package { name, version, description: String::new(), source, installed });
+            current = Some(Package {
+                name,
+                version,
+                description: String::new(),
+                source,
+                installed,
+            });
         } else if let Some(ref mut pkg) = current {
             let desc = line.trim_start();
             if !desc.is_empty() {
@@ -84,7 +94,10 @@ impl Provider for PacmanProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
@@ -105,21 +118,29 @@ impl Provider for PacmanProvider {
 
         let output = exec_command(&format!("pacman -Ss '{escaped}' 2>/dev/null"));
         if output.is_empty() && exact_match.is_none() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let mut packages = parse_ss_output(&output);
 
         // Add exact match if not already present
         if let Some(em) = exact_match {
-            let already = packages.iter().any(|p| p.name == em.name && p.source == em.source);
+            let already = packages
+                .iter()
+                .any(|p| p.name == em.name && p.source == em.source);
             if !already {
                 packages.insert(0, em);
             }
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/paru.rs
+++ b/src/providers/paru.rs
@@ -48,10 +48,14 @@ fn parse_ss_output(output: &str) -> Vec<Package> {
             if let Some(pkg) = current.take() {
                 packages.push(pkg);
             }
-            let Some(slash) = line.find('/') else { continue };
+            let Some(slash) = line.find('/') else {
+                continue;
+            };
             let source = line[..slash].to_string();
             let rest = &line[slash + 1..];
-            let Some(space) = rest.find(' ') else { continue };
+            let Some(space) = rest.find(' ') else {
+                continue;
+            };
             let name = rest[..space].to_string();
             let version = rest[space + 1..]
                 .split_whitespace()
@@ -59,7 +63,13 @@ fn parse_ss_output(output: &str) -> Vec<Package> {
                 .unwrap_or("")
                 .to_string();
             let installed = line.contains("[installed]") || line.contains("[Installed]");
-            current = Some(Package { name, version, description: String::new(), source, installed });
+            current = Some(Package {
+                name,
+                version,
+                description: String::new(),
+                source,
+                installed,
+            });
         } else if let Some(ref mut pkg) = current {
             let desc = line.trim_start();
             if !desc.is_empty() {
@@ -84,7 +94,10 @@ impl Provider for ParuProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
@@ -114,14 +127,19 @@ impl Provider for ParuProvider {
         let mut packages = parse_ss_output(&stdout);
 
         if let Some(em) = exact_match {
-            let already = packages.iter().any(|p| p.name == em.name && p.source == em.source);
+            let already = packages
+                .iter()
+                .any(|p| p.name == em.name && p.source == em.source);
             if !already {
                 packages.insert(0, em);
             }
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/snap.rs
+++ b/src/providers/snap.rs
@@ -31,13 +31,19 @@ impl Provider for SnapProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
         let output = exec_command(&format!("snap find '{escaped}' 2>/dev/null"));
         if output.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let installed = get_installed();
@@ -56,7 +62,11 @@ impl Provider for SnapProvider {
                 continue;
             }
             let name = cols[0].trim().to_string();
-            let version = if cols.len() > 1 { cols[1].trim().to_string() } else { String::new() };
+            let version = if cols.len() > 1 {
+                cols[1].trim().to_string()
+            } else {
+                String::new()
+            };
             let description = if cols.len() > 4 {
                 cols[4..].join("  ").trim().to_string()
             } else if cols.len() > 3 {
@@ -80,7 +90,10 @@ impl Provider for SnapProvider {
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/xbps.rs
+++ b/src/providers/xbps.rs
@@ -24,13 +24,19 @@ impl Provider for XbpsProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
         let output = exec_command(&format!("xbps-query -Rs '{escaped}' 2>/dev/null"));
         if output.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let mut packages = Vec::new();
@@ -72,7 +78,10 @@ impl Provider for XbpsProvider {
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/yay.rs
+++ b/src/providers/yay.rs
@@ -48,10 +48,14 @@ fn parse_ss_output(output: &str) -> Vec<Package> {
             if let Some(pkg) = current.take() {
                 packages.push(pkg);
             }
-            let Some(slash) = line.find('/') else { continue };
+            let Some(slash) = line.find('/') else {
+                continue;
+            };
             let source = line[..slash].to_string();
             let rest = &line[slash + 1..];
-            let Some(space) = rest.find(' ') else { continue };
+            let Some(space) = rest.find(' ') else {
+                continue;
+            };
             let name = rest[..space].to_string();
             let version = rest[space + 1..]
                 .split_whitespace()
@@ -59,7 +63,13 @@ fn parse_ss_output(output: &str) -> Vec<Package> {
                 .unwrap_or("")
                 .to_string();
             let installed = line.contains("[installed]") || line.contains("[Installed]");
-            current = Some(Package { name, version, description: String::new(), source, installed });
+            current = Some(Package {
+                name,
+                version,
+                description: String::new(),
+                source,
+                installed,
+            });
         } else if let Some(ref mut pkg) = current {
             let desc = line.trim_start();
             if !desc.is_empty() {
@@ -84,7 +94,10 @@ impl Provider for YayProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
@@ -98,8 +111,7 @@ impl Provider for YayProvider {
         }
 
         // Main search with --topdown to show repo packages first
-        let (stdout, stderr, _) =
-            exec_command_full(&format!("yay --topdown -Ss '{escaped}'"));
+        let (stdout, stderr, _) = exec_command_full(&format!("yay --topdown -Ss '{escaped}'"));
 
         if stderr.contains("Query arg too small")
             || stderr.contains("Too many package results")
@@ -115,14 +127,19 @@ impl Provider for YayProvider {
         let mut packages = parse_ss_output(&stdout);
 
         if let Some(em) = exact_match {
-            let already = packages.iter().any(|p| p.name == em.name && p.source == em.source);
+            let already = packages
+                .iter()
+                .any(|p| p.name == em.name && p.source == em.source);
             if !already {
                 packages.insert(0, em);
             }
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/zerobrew.rs
+++ b/src/providers/zerobrew.rs
@@ -1,26 +1,10 @@
-use std::collections::HashSet;
-
 use ratatui::style::Color;
 
 use crate::provider::{Package, Provider, SearchResult};
-use crate::util::{command_exists, escape_query, exec_command, sort_by_relevance};
+use crate::providers::homebrew_index;
+use crate::util::command_exists;
 
 pub struct ZerobrewProvider;
-
-fn get_installed() -> HashSet<String> {
-    let mut installed = HashSet::new();
-    for output in [
-        exec_command("brew list --formula 2>/dev/null"),
-        exec_command("brew list --cask 2>/dev/null"),
-    ] {
-        for line in output.lines() {
-            if !line.is_empty() {
-                installed.insert(line.to_string());
-            }
-        }
-    }
-    installed
-}
 
 impl Provider for ZerobrewProvider {
     fn name(&self) -> &str {
@@ -32,93 +16,7 @@ impl Provider for ZerobrewProvider {
     }
 
     fn search(&self, query: &str) -> SearchResult {
-        if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
-        }
-
-        let escaped = escape_query(query);
-        let installed = get_installed();
-
-        // Try exact match via brew info
-        let mut exact_match: Option<Package> = None;
-        let info_output = exec_command(&format!("brew info '{escaped}' 2>/dev/null"));
-        if !info_output.is_empty() && !info_output.contains("Error:") {
-            let mut lines = info_output.lines();
-            if let Some(first_line) = lines.next() {
-                let first_line = first_line.strip_prefix("==> ").unwrap_or(first_line);
-                if let Some(colon) = first_line.find(": ") {
-                    let name = first_line[..colon].to_string();
-                    let description = lines
-                        .find(|l| {
-                            !l.is_empty()
-                                && !l.starts_with('=')
-                                && !l.starts_with("http")
-                                && !l.starts_with("Installed")
-                                && !l.starts_with("From:")
-                                && !l.starts_with("License:")
-                        })
-                        .unwrap_or("")
-                        .to_string();
-                    let is_installed = installed.contains(&name);
-                    exact_match = Some(Package {
-                        name,
-                        version: String::new(),
-                        description,
-                        source: "formula".to_string(),
-                        installed: is_installed,
-                    });
-                }
-            }
-        }
-
-        let output = exec_command(&format!("brew search --desc '{escaped}' 2>/dev/null"));
-
-        let mut packages = Vec::new();
-
-        let exact_name = exact_match.as_ref().map(|p| p.name.clone()).unwrap_or_default();
-        if let Some(em) = exact_match {
-            packages.push(em);
-        }
-
-        let mut current_source = "formula";
-        for line in output.lines() {
-            if line.is_empty() {
-                continue;
-            }
-            if line.contains("==> Formulae") {
-                current_source = "formula";
-                continue;
-            }
-            if line.contains("==> Casks") {
-                current_source = "cask";
-                continue;
-            }
-            if line.starts_with('=') || line.starts_with("No ") {
-                continue;
-            }
-
-            let (name, description) = if let Some(colon) = line.find(": ") {
-                (line[..colon].to_string(), line[colon + 2..].to_string())
-            } else {
-                (line.trim().to_string(), String::new())
-            };
-
-            if name.is_empty() || name == exact_name {
-                continue;
-            }
-
-            let is_installed = installed.contains(&name);
-            packages.push(Package {
-                name,
-                version: String::new(),
-                description,
-                source: current_source.to_string(),
-                installed: is_installed,
-            });
-        }
-
-        sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        homebrew_index::search(query)
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/providers/zypper.rs
+++ b/src/providers/zypper.rs
@@ -25,14 +25,16 @@ impl Provider for ZypperProvider {
 
     fn search(&self, query: &str) -> SearchResult {
         if query.is_empty() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let escaped = escape_query(query);
 
         // Try exact match via zypper info
-        let info_output =
-            exec_command(&format!("zypper --quiet info '{escaped}' 2>/dev/null"));
+        let info_output = exec_command(&format!("zypper --quiet info '{escaped}' 2>/dev/null"));
         let mut exact_match: Option<Package> = None;
         if !info_output.is_empty() && !info_output.contains("not found") {
             let mut pkg = Package {
@@ -60,10 +62,12 @@ impl Provider for ZypperProvider {
             }
         }
 
-        let output =
-            exec_command(&format!("zypper --quiet search '{escaped}' 2>/dev/null"));
+        let output = exec_command(&format!("zypper --quiet search '{escaped}' 2>/dev/null"));
         if output.is_empty() && exact_match.is_none() {
-            return SearchResult { packages: vec![], error: None };
+            return SearchResult {
+                packages: vec![],
+                error: None,
+            };
         }
 
         let mut packages = Vec::new();
@@ -116,7 +120,10 @@ impl Provider for ZypperProvider {
         }
 
         sort_by_relevance(&mut packages, query);
-        SearchResult { packages, error: None }
+        SearchResult {
+            packages,
+            error: None,
+        }
     }
 
     fn install_command(&self, pkg: &Package) -> String {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -66,7 +66,9 @@ fn render_results(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
             let installed_span = if pkg.installed {
                 Span::styled(
                     " *",
-                    Style::new().fg(Color::Green).add_modifier(Modifier::REVERSED),
+                    Style::new()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::REVERSED),
                 )
             } else {
                 Span::styled("  ", Style::new().add_modifier(Modifier::REVERSED))
@@ -90,7 +92,11 @@ fn render_results(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
                 pkg.source,
                 if pkg.installed { " *" } else { "  " },
                 pkg.name,
-                if pkg.version.is_empty() { String::new() } else { format!(" {}", pkg.version) }
+                if pkg.version.is_empty() {
+                    String::new()
+                } else {
+                    format!(" {}", pkg.version)
+                }
             );
             let pad_len = width.saturating_sub(header_text.len());
             let pad_span = Span::styled(
@@ -111,7 +117,10 @@ fn render_results(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
             let desc = truncate(&pkg.description, max_desc);
             let desc_pad = " ".repeat(width.saturating_sub(9 + desc.len()));
             lines.push(Line::from(vec![
-                Span::styled(format!("{indent}{desc}"), Style::new().add_modifier(Modifier::REVERSED)),
+                Span::styled(
+                    format!("{indent}{desc}"),
+                    Style::new().add_modifier(Modifier::REVERSED),
+                ),
                 Span::styled(desc_pad, Style::new().add_modifier(Modifier::REVERSED)),
             ]));
         } else {
@@ -123,8 +132,10 @@ fn render_results(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
             } else {
                 Span::raw("  ")
             };
-            let name_span =
-                Span::styled(format!(" {}", pkg.name), Style::new().add_modifier(Modifier::BOLD));
+            let name_span = Span::styled(
+                format!(" {}", pkg.name),
+                Style::new().add_modifier(Modifier::BOLD),
+            );
             let version_part = if pkg.version.is_empty() {
                 String::new()
             } else {
@@ -160,9 +171,7 @@ fn render_status(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         SearchState::Idle => "",
     };
 
-    let status_text = format!(
-        " provider: {provider_name} │ {n} results{search_indicator}"
-    );
+    let status_text = format!(" provider: {provider_name} │ {n} results{search_indicator}");
 
     let style = match app.search_state {
         SearchState::Searching => Style::new().fg(Color::Yellow),
@@ -191,9 +200,7 @@ fn render_status(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
 }
 
 fn render_search(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .title(" Search ");
+    let block = Block::default().borders(Borders::ALL).title(" Search ");
 
     let inner = block.inner(area);
     f.render_widget(block, area);

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,11 +27,7 @@ pub fn exec_command(cmd: &str) -> String {
 
 /// Execute a shell command and return (stdout, stderr, exit_code).
 pub fn exec_command_full(cmd: &str) -> (String, String, i32) {
-    match std::process::Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
-        .output()
-    {
+    match std::process::Command::new("sh").arg("-c").arg(cmd).output() {
         Ok(output) => (
             String::from_utf8_lossy(&output.stdout).into_owned(),
             String::from_utf8_lossy(&output.stderr).into_owned(),


### PR DESCRIPTION
Actually insane speedup, fetches the full list of things in under a second and caches in app memory (so you fetch latest if you restart fex) and then uses rust to search that, actually a really good pattern. 

Might want to extend it to other providers later where applicable.

Closes #4 

> also ran cargo fmt